### PR TITLE
Slow down bg block producing for stability

### DIFF
--- a/etc/mocha.global.ts
+++ b/etc/mocha.global.ts
@@ -10,7 +10,7 @@ chai.use(chaiAsPromised);
 const logger = new Logger('Test / Mocha');
 
 before(async function() {
-    this.timeout(30 * 1000);
+    this.timeout(60 * 1000);
     
     this.runtimeContext = await RuntimeContext.getSingleton();
     this.stackManager = new StackManager(this.runtimeContext);

--- a/src/service/project/StackManager.ts
+++ b/src/service/project/StackManager.ts
@@ -82,7 +82,7 @@ export class StackManager
     {
         const options : StackComponentOptions = cloneDeep(this._context.config.stack.node);
         if (mode === SpawnMode.Background) {
-            options.args['--block-millisecs'] = 100;
+            options.args['--block-millisecs'] = 500;
         }
         
         return this._startComponent(


### PR DESCRIPTION
100ms is too aggressive. It may cause some tx being dropped when doing a more complex chain initialization setup. I personally found 500ms a good balance.

Also loosen the setup timeout from 30s to 60s.