### PR TITLE
Fix package version mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "tsconfig-paths": "^4.1.0"
     },
     "peerDependencies": {
-        "@polkadot/api": "9.8.1",
+        "@polkadot/api": "^9.8.1",
         "@polkadot/api-contract": "^9.8.1",
         "@polkadot/keyring": "^10.1.12",
         "@polkadot/util": "^10.1.12",


### PR DESCRIPTION
I was getting duplicated packages w/ version mismatches since `@polkadot/api` is set to `9.8.1` and the other versions are using the latest.