### PR TITLE
Add Phat Hello and Signing Templates w/ Tests

### DIFF
--- a/workspaces/xsandbox/contracts/phat_hello/Cargo.toml
+++ b/workspaces/xsandbox/contracts/phat_hello/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "phat_hello"
+version = "0.1.0"
+authors = ["[your_name] <[your_email]>"]
+edition = "2021"
+
+[dependencies]
+ink = { version = "4", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.1", default-features = false, features = ["derive"], optional = true }
+
+serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde-json-core = { version = "0.4.0" }
+
+pink-extension = { version = "0.4", default-features = false }
+
+[dev-dependencies]
+pink-extension-runtime = { version = "0.4", default-features = false }
+
+[lib]
+name = "phat_hello"
+path = "lib.rs"
+crate-type = [
+	# Used for normal contract Wasm blobs.
+	"cdylib",
+]
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+    "pink-extension/std",
+    "serde-json-core/std",
+]
+ink-as-dependency = []

--- a/workspaces/xsandbox/contracts/phat_hello/lib.rs
+++ b/workspaces/xsandbox/contracts/phat_hello/lib.rs
@@ -1,0 +1,102 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+
+// pink_extension is short for Phala ink! extension
+use pink_extension as pink;
+
+#[pink::contract(env=PinkEnvironment)]
+mod phat_hello {
+    use super::pink;
+    use pink::{http_get, PinkEnvironment};
+    use scale::{Decode, Encode};
+    use serde::Deserialize;
+    use alloc::string::String;
+    use alloc::format;
+
+    // you have to use crates with `no_std` support in contract.
+    use serde_json_core;
+
+    #[derive(Debug, PartialEq, Eq, Encode, Decode)]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub enum Error {
+        InvalidEthAddress,
+        HttpRequestFailed,
+        InvalidResponseBody,
+    }
+
+    /// Type alias for the contract's result type.
+    pub type Result<T> = core::result::Result<T, Error>;
+
+    /// Defines the storage of your contract.
+    /// All the fields will be encrypted and stored on-chain.
+    /// In this stateless example, we just add a useless field for demo.
+    #[ink(storage)]
+    pub struct PhatHello {
+        demo_field: bool,
+    }
+
+    #[derive(Deserialize, Encode, Clone, Debug, PartialEq)]
+    pub struct EtherscanResponse<'a> {
+        status: &'a str,
+        message: &'a str,
+        result: &'a str,
+    }
+
+    impl PhatHello {
+        /// Constructor to initializes your contract
+        #[ink(constructor)]
+        pub fn new() -> Self {
+            Self { demo_field: true }
+        }
+
+        /// A function to handle direct off-chain Query from users.
+        /// Such functions use the immutable reference `&self`
+        /// so WILL NOT change the contract state.
+        #[ink(message)]
+        pub fn get_eth_balance(&self, account: String) -> Result<String> {
+            if !account.starts_with("0x") && account.len() != 42 {
+                return Err(Error::InvalidEthAddress);
+            }
+
+            // get account ETH balance with HTTP requests to Etherscan
+            // you can send any HTTP requests in Query handler
+            let resp = http_get!(format!(
+                "https://api.etherscan.io/api?module=account&action=balance&address={}",
+                account
+            ));
+            if resp.status_code != 200 {
+                return Err(Error::HttpRequestFailed);
+            }
+
+            let result: EtherscanResponse = serde_json_core::from_slice(&resp.body)
+                .or(Err(Error::InvalidResponseBody))?
+                .0;
+            Ok(String::from(result.result))
+        }
+    }
+
+    /// Unit tests in Rust are normally defined within such a `#[cfg(test)]`
+    /// module and test functions are marked with a `#[test]` attribute.
+    /// The below code is technically just normal Rust code.
+    #[cfg(test)]
+    mod tests {
+        /// Imports all the definitions from the outer scope so we can use them here.
+        use super::*;
+
+        /// We test a simple use case of our contract.
+        #[ink::test]
+        fn it_works() {
+            // when your contract is really deployed, the Phala Worker will do the HTTP requests
+            // mock is needed for local test
+            pink_extension_runtime::mock_ext::mock_all_ext();
+
+            let phat_hello = PhatHello::new();
+            let account = String::from("0xD0fE316B9f01A3b5fd6790F88C2D53739F80B464");
+            let res = phat_hello.get_eth_balance(account.clone());
+            assert!(res.is_ok());
+
+            // run with `cargo +nightly test -- --nocapture` to see the following output
+            println!("Account {} gets {} Wei", account, res.unwrap());
+        }
+    }
+}

--- a/workspaces/xsandbox/contracts/signing/Cargo.toml
+++ b/workspaces/xsandbox/contracts/signing/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "signing"
+version = "0.1.0"
+authors = ["[your_name] <[your_email]>"]
+edition = "2021"
+rust-version = "1.56.1"
+
+[dependencies]
+ink = { version = "4", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.1", default-features = false, features = ["derive"], optional = true }
+
+pink-extension = { version = "0.4", default-features = false }
+
+[dev-dependencies]
+pink-extension-runtime = "0.4"
+
+[lib]
+name = "signing"
+path = "lib.rs"
+crate-type = [
+	# Used for normal contract Wasm blobs.
+	"cdylib",
+]
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+    "pink-extension/std",
+]
+ink-as-dependency = []

--- a/workspaces/xsandbox/contracts/signing/lib.rs
+++ b/workspaces/xsandbox/contracts/signing/lib.rs
@@ -1,0 +1,48 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+
+use pink_extension as pink;
+
+#[pink::contract(env=PinkEnvironment)]
+mod signing {
+    use super::pink;
+    use pink::chain_extension::signing as sig;
+    use pink::PinkEnvironment;
+
+    #[ink(storage)]
+    pub struct Signing {}
+
+    impl Signing {
+        #[ink(constructor)]
+        pub fn default() -> Self {
+            Self {}
+        }
+
+        #[ink(message)]
+        pub fn test(&self) {
+            use sig::SigType;
+
+            let privkey = sig::derive_sr25519_key(b"a spoon of salt");
+            let pubkey = sig::get_public_key(&privkey, SigType::Sr25519);
+            let message = b"hello world";
+            let signature = sig::sign(message, &privkey, SigType::Sr25519);
+            let pass = sig::verify(message, &pubkey, &signature, SigType::Sr25519);
+            assert!(pass);
+            let pass = sig::verify(b"Fake", &pubkey, &signature, SigType::Sr25519);
+            assert!(!pass);
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[ink::test]
+        fn it_works() {
+            pink_extension_runtime::mock_ext::mock_all_ext();
+
+            let contract = Signing::default();
+            contract.test();
+        }
+    }
+}

--- a/workspaces/xsandbox/contracts/signing/lib.rs
+++ b/workspaces/xsandbox/contracts/signing/lib.rs
@@ -7,28 +7,46 @@ use pink_extension as pink;
 mod signing {
     use super::pink;
     use pink::chain_extension::signing as sig;
+    use sig::SigType;
     use pink::PinkEnvironment;
+    use alloc::{string::String, vec::Vec};
 
     #[ink(storage)]
-    pub struct Signing {}
+    pub struct Signing {
+        privkey: Vec<u8>,
+        pubkey: Vec<u8>,
+    }
 
     impl Signing {
         #[ink(constructor)]
         pub fn default() -> Self {
-            Self {}
+            let gen_privkey = sig::derive_sr25519_key(b"a spoon of salt");
+            let gen_pubkey = sig::get_public_key(&gen_privkey, SigType::Sr25519);
+            Self {
+                privkey: gen_privkey,
+                pubkey: gen_pubkey,
+            }
         }
 
         #[ink(message)]
-        pub fn test(&self) {
-            use sig::SigType;
+        pub fn sign(&self, message: String) -> Vec<u8> {
+            let signature = sig::sign(message.as_bytes(), &self.privkey, SigType::Sr25519);
+            signature
+        }
 
-            let privkey = sig::derive_sr25519_key(b"a spoon of salt");
-            let pubkey = sig::get_public_key(&privkey, SigType::Sr25519);
-            let message = b"hello world";
-            let signature = sig::sign(message, &privkey, SigType::Sr25519);
-            let pass = sig::verify(message, &pubkey, &signature, SigType::Sr25519);
+        #[ink(message)]
+        pub fn verify(&self, message: String, signature: Vec<u8>) -> bool {
+            let pass = sig::verify(message.as_bytes(), &self.pubkey, &signature, SigType::Sr25519);
+            pass
+        }
+
+        #[ink(message)]
+        pub fn test(&self, message: String) {
+            let message_bytes = message.as_bytes();
+            let signature = sig::sign(message_bytes, &self.privkey, SigType::Sr25519);
+            let pass = sig::verify(message_bytes, &self.pubkey, &signature, SigType::Sr25519);
             assert!(pass);
-            let pass = sig::verify(b"Fake", &pubkey, &signature, SigType::Sr25519);
+            let pass = sig::verify(b"Fake", &self.pubkey, &signature, SigType::Sr25519);
             assert!(!pass);
         }
     }
@@ -42,7 +60,11 @@ mod signing {
             pink_extension_runtime::mock_ext::mock_all_ext();
 
             let contract = Signing::default();
-            contract.test();
+            let message = String::from("hello world");
+            let sign_message = contract.sign(message.clone());
+            let verify_signature = contract.verify(message.clone(), sign_message);
+            assert!(verify_signature);
+            contract.test(message);
         }
     }
 }

--- a/workspaces/xsandbox/tests/phat_hello/phat_hello.test.ts
+++ b/workspaces/xsandbox/tests/phat_hello/phat_hello.test.ts
@@ -1,0 +1,41 @@
+import { PhatHello } from '@/typings/PhatHello';
+import * as PhalaSdk from '@phala/sdk';
+import type { KeyringPair } from '@polkadot/keyring/types';
+import { ContractType } from '@devphase/service';
+
+
+describe('PhatHello', () => {
+    let factory : PhatHello.Factory;
+    let contract : PhatHello.Contract;
+    let signer : KeyringPair;
+    let certificate : PhalaSdk.CertificateData;
+
+    before(async function() {
+        factory = await this.devPhase.getFactory(
+            './contracts/phat_hello/target/ink/phat_hello.contract',
+            {
+                contractType: ContractType.InkCode,
+            }
+        );
+
+        await factory.deploy();
+
+        signer = this.devPhase.accounts.bob;
+        certificate = await PhalaSdk.signCertificate({
+            api: this.api,
+            pair: signer,
+        });
+    });
+
+    describe('new constructor', () => {
+        before(async function() {
+            contract = await factory.instantiate('new', {});
+        });
+
+        it('Should be able to query balance of an account on Ethereum', async function() {
+            const response = await contract.query.get_eth_balance(certificate, ['0xD0fE316B9f01A3b5fd6790F88C2D53739F80B464']);
+            console.log(response.output.toJSON());
+        });
+    });
+
+});

--- a/workspaces/xsandbox/tests/phat_hello/phat_hello.test.ts
+++ b/workspaces/xsandbox/tests/phat_hello/phat_hello.test.ts
@@ -1,6 +1,7 @@
 import { PhatHello } from '@/typings/PhatHello';
 import * as PhalaSdk from '@phala/sdk';
 import type { KeyringPair } from '@polkadot/keyring/types';
+import { stringToHex } from '@polkadot/util';
 import { ContractType } from '@devphase/service';
 
 
@@ -29,11 +30,13 @@ describe('PhatHello', () => {
 
     describe('new constructor', () => {
         before(async function() {
-            contract = await factory.instantiate('new', {});
+            contract = await factory.instantiate('new', []);
         });
+        const address = "0xD0fE316B9f01A3b5fd6790F88C2D53739F80B464";
+        const hex_address = stringToHex(address)
 
         it('Should be able to query balance of an account on Ethereum', async function() {
-            const response = await contract.query.get_eth_balance(certificate, ['0xD0fE316B9f01A3b5fd6790F88C2D53739F80B464']);
+            const response = await contract.query.getEthBalance(certificate, {}, hex_address);
             console.log(response.output.toJSON());
         });
     });

--- a/workspaces/xsandbox/tests/signing/signing.test.ts
+++ b/workspaces/xsandbox/tests/signing/signing.test.ts
@@ -2,6 +2,7 @@ import { Signing } from '@/typings/Signing';
 import * as PhalaSdk from '@phala/sdk';
 import type { KeyringPair } from '@polkadot/keyring/types';
 import { ContractType } from '@devphase/service';
+import { stringToU8a } from '@polkadot/util';
 
 
 describe('Signing', () => {
@@ -29,11 +30,12 @@ describe('Signing', () => {
 
     describe('default constructor', () => {
         before(async function() {
-            contract = await factory.instantiate('default', {});
+            contract = await factory.instantiate('default', []);
         });
+        const message = "hi, how are ya?";
 
-        it('Should be able to query balance of an account on Ethereum', async function() {
-            const response = await contract.query.test(certificate, {});
+        it('Should be able derive keypair & sign/verify messages', async function() {
+            const response = await contract.query.test(certificate, {}, message);
             console.log(response.output.toJSON());
         });
     });

--- a/workspaces/xsandbox/tests/signing/signing.test.ts
+++ b/workspaces/xsandbox/tests/signing/signing.test.ts
@@ -1,0 +1,41 @@
+import { Signing } from '@/typings/Signing';
+import * as PhalaSdk from '@phala/sdk';
+import type { KeyringPair } from '@polkadot/keyring/types';
+import { ContractType } from '@devphase/service';
+
+
+describe('Signing', () => {
+    let factory : Signing.Factory;
+    let contract : Signing.Contract;
+    let signer : KeyringPair;
+    let certificate : PhalaSdk.CertificateData;
+
+    before(async function() {
+        factory = await this.devPhase.getFactory(
+            './contracts/signing/target/ink/signing.contract',
+            {
+                contractType: ContractType.InkCode,
+            }
+        );
+
+        await factory.deploy();
+
+        signer = this.devPhase.accounts.bob;
+        certificate = await PhalaSdk.signCertificate({
+            api: this.api,
+            pair: signer,
+        });
+    });
+
+    describe('default constructor', () => {
+        before(async function() {
+            contract = await factory.instantiate('default', {});
+        });
+
+        it('Should be able to query balance of an account on Ethereum', async function() {
+            const response = await contract.query.test(certificate, {});
+            console.log(response.output.toJSON());
+        });
+    });
+
+});

--- a/workspaces/xsandbox/typings/PhatHello.ts
+++ b/workspaces/xsandbox/typings/PhatHello.ts
@@ -1,0 +1,49 @@
+import type * as PhalaSdk from "@phala/sdk";
+import type * as DevPhase from "@devphase/service";
+import type * as DPT from "@devphase/service/etc/typings";
+import type { ContractCallResult, ContractQuery } from "@polkadot/api-contract/base/types";
+import type { ContractCallOutcome, ContractOptions } from "@polkadot/api-contract/types";
+import type { Codec } from "@polkadot/types/types";
+
+export namespace PhatHello {
+    type InkPrimitives_LangError = { CouldNotReadInput: null };
+    type Result = { Ok: Result } | { Err: InkPrimitives_LangError };
+    type PhatHello_PhatHello_Error = { InvalidEthAddress: null } | { HttpRequestFailed: null } | { InvalidResponseBody: null };
+
+    /** */
+    /** Queries */
+    /** */
+    namespace ContractQuery {
+        export interface GetEthBalance extends DPT.ContractQuery {
+            (certificateData: PhalaSdk.CertificateData, options: ContractOptions, account: string): DPT.CallResult<DPT.CallOutcome<DPT.IJson<Result>>>;
+        }
+    }
+
+    export interface MapMessageQuery extends DPT.MapMessageQuery {
+        getEthBalance: ContractQuery.GetEthBalance;
+    }
+
+    /** */
+    /** Transactions */
+    /** */
+    namespace ContractTx {
+    }
+
+    export interface MapMessageTx extends DPT.MapMessageTx {
+    }
+
+    /** */
+    /** Contract */
+    /** */
+    export declare class Contract extends DPT.Contract {
+        get query(): MapMessageQuery;
+        get tx(): MapMessageTx;
+    }
+
+    /** */
+    /** Contract factory */
+    /** */
+    export declare class Factory extends DevPhase.ContractFactory {
+        instantiate<T = Contract>(constructor: "new", params: never[], options?: DevPhase.InstantiateOptions): Promise<T>;
+    }
+}

--- a/workspaces/xsandbox/typings/Signing.ts
+++ b/workspaces/xsandbox/typings/Signing.ts
@@ -1,0 +1,48 @@
+import type * as PhalaSdk from "@phala/sdk";
+import type * as DevPhase from "@devphase/service";
+import type * as DPT from "@devphase/service/etc/typings";
+import type { ContractCallResult, ContractQuery } from "@polkadot/api-contract/base/types";
+import type { ContractCallOutcome, ContractOptions } from "@polkadot/api-contract/types";
+import type { Codec } from "@polkadot/types/types";
+
+export namespace Signing {
+    type InkPrimitives_LangError = { CouldNotReadInput: null };
+    type Result = { Ok: never[] } | { Err: InkPrimitives_LangError };
+
+    /** */
+    /** Queries */
+    /** */
+    namespace ContractQuery {
+        export interface Test extends DPT.ContractQuery {
+            (certificateData: PhalaSdk.CertificateData, options: ContractOptions): DPT.CallResult<DPT.CallOutcome<DPT.IJson<Result>>>;
+        }
+    }
+
+    export interface MapMessageQuery extends DPT.MapMessageQuery {
+        test: ContractQuery.Test;
+    }
+
+    /** */
+    /** Transactions */
+    /** */
+    namespace ContractTx {
+    }
+
+    export interface MapMessageTx extends DPT.MapMessageTx {
+    }
+
+    /** */
+    /** Contract */
+    /** */
+    export declare class Contract extends DPT.Contract {
+        get query(): MapMessageQuery;
+        get tx(): MapMessageTx;
+    }
+
+    /** */
+    /** Contract factory */
+    /** */
+    export declare class Factory extends DevPhase.ContractFactory {
+        instantiate<T = Contract>(constructor: "default", params: never[], options?: DevPhase.InstantiateOptions): Promise<T>;
+    }
+}

--- a/workspaces/xsandbox/typings/Signing.ts
+++ b/workspaces/xsandbox/typings/Signing.ts
@@ -7,18 +7,28 @@ import type { Codec } from "@polkadot/types/types";
 
 export namespace Signing {
     type InkPrimitives_LangError = { CouldNotReadInput: null };
-    type Result = { Ok: never[] } | { Err: InkPrimitives_LangError };
+    type Result = { Ok: boolean } | { Err: InkPrimitives_LangError };
 
     /** */
     /** Queries */
     /** */
     namespace ContractQuery {
+        export interface Sign extends DPT.ContractQuery {
+            (certificateData: PhalaSdk.CertificateData, options: ContractOptions, message: string): DPT.CallResult<DPT.CallOutcome<DPT.IJson<Result>>>;
+        }
+
+        export interface Verify extends DPT.ContractQuery {
+            (certificateData: PhalaSdk.CertificateData, options: ContractOptions, message: string, signature: number[]): DPT.CallResult<DPT.CallOutcome<DPT.IJson<Result>>>;
+        }
+
         export interface Test extends DPT.ContractQuery {
-            (certificateData: PhalaSdk.CertificateData, options: ContractOptions): DPT.CallResult<DPT.CallOutcome<DPT.IJson<Result>>>;
+            (certificateData: PhalaSdk.CertificateData, options: ContractOptions, message: string): DPT.CallResult<DPT.CallOutcome<DPT.IJson<Result>>>;
         }
     }
 
     export interface MapMessageQuery extends DPT.MapMessageQuery {
+        sign: ContractQuery.Sign;
+        verify: ContractQuery.Verify;
         test: ContractQuery.Test;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,17 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@devphase/cli@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@devphase/cli/-/cli-0.0.1.tgz#5af096052a3a57a47d687db8087aecf4dc47b40c"
+  integrity sha512-oh0plqUqAV2NInAX4cl5x7IiZ0n2xHtQViGubi7ox359iiaLKsCGNsafBlO7wgY49CGRUsEbSQiCyJvVPW4Ipw==
+  dependencies:
+    "@devphase/service" "^0.0.1"
+    "@oclif/core" "^2.0.7"
+    "@oclif/plugin-help" "^5.2.2"
+    "@oclif/plugin-plugins" "^2.2.4"
+    listr "^0.14.3"
+
 "@esbuild-plugins/node-modules-polyfill@^0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.1.4.tgz#eb2f55da11967b2986c913f1a7957d1c868849c0"


### PR DESCRIPTION
## Description
Currently the `devphase` `xsandbox` has one template contract for testing the `Flipper` Phat Contract. To expand on examples and have working tests in a local test environment, I've added two boilerplate examples for `PhatHello` and `Signing` with a test set for each.

## Targets
- [x] Add `PhatHello` and `Signing` Phat Contracts
- [x] Add Tests for each new Phat Contract
  - [x] Phat Hello had a unique error for adding a hex address to a query. The test added is an example on how to resolve that issue by using `stringToHex()` 
- [x] Execute test locally to ensure tests pass

#### Phat Hello
```
┌─[hashwarlock@wrlx-tun311-33] - [~/Projects/Phala/Swanky/demo/devphase/workspaces/xsandbox] - [Sat Mar 25, 20:15]
└─[$]> yarn devphase contract test -s phat_hello
yarn run v1.22.19
$ /home/hashwarlock/Projects/Phala/Swanky/demo/devphase/workspaces/xsandbox/node_modules/.bin/devphase contract test -s phat_hello
[StackBinaryDownloader] Preparing Phala stack release
  ✔ Checking releases directory
  ✔ Checking target release binaries
0x307844306645333136423966303141336235666436373930463838433244353337333946383042343634


[Test] Global setup start
[Test] Preparing dev stack
[StackManager] Starting stack
  ✔ Start node component
  ✔ Start pRuntime component
  ✔ Start pherry component
[Test] Init API
[Test] Setup environment
[StackSetupService] Starting stack setup with default version
  ✔ Fetch worker info
  ↓ Register worker [skipped]
  ✔ Register gatekeeper
  ✔ Load system contracts
  ✔ Upload Pink system code
  ✔ Verify cluster
  ✔ Create cluster
  ✔ Wait for cluster to be ready
  ✔ Create system contract API
[Test] Global setup done
[Test] Starting tests
  PhatHello
    new constructor
{ ok: { ok: '20950198739626844' } }
      ✔ Should be able to query balance of an account on Ethereum (2983ms)

[Test] Global teardown start
[Test] Internal clean up
[Test] Stopping stack
[Test] Global teardown done

  1 passing (22s)

Done in 25.89s.
```
#### Signing
```
┌─[hashwarlock@wrlx-tun311-33] - [~/Projects/Phala/Swanky/demo/devphase/workspaces/xsandbox] - [Sat Mar 25, 20:54]
└─[$]> yarn devphase contract compile -c signing
yarn run v1.22.19
$ /home/hashwarlock/Projects/Phala/Swanky/demo/devphase/workspaces/xsandbox/node_modules/.bin/devphase contract compile -c signing
[MultiContractExecutor] Criteria: signing
[MultiContractExecutor] Matched contracts:
[MultiContractExecutor] signing
[MultiContractExecutor] 
  ❯ signing
  ✔ signing
Done in 3.51s.
┌─[hashwarlock@wrlx-tun311-33] - [~/Projects/Phala/Swanky/demo/devphase/workspaces/xsandbox] - [Sat Mar 25, 20:54]
└─[$]> yarn devphase contract test -s signing   
yarn run v1.22.19
$ /home/hashwarlock/Projects/Phala/Swanky/demo/devphase/workspaces/xsandbox/node_modules/.bin/devphase contract test -s signing
[StackBinaryDownloader] Preparing Phala stack release
  ✔ Checking releases directory
  ✔ Checking target release binaries


[Test] Global setup start
[Test] Preparing dev stack
[StackManager] Starting stack
  ✔ Start node component
  ✔ Start pRuntime component
  ✔ Start pherry component
[Test] Init API
[Test] Setup environment
[StackSetupService] Starting stack setup with default version
  ✔ Fetch worker info
  ↓ Register worker [skipped]
  ✔ Register gatekeeper
  ✔ Load system contracts
  ✔ Upload Pink system code
  ✔ Verify cluster
  ✔ Create cluster
  ✔ Wait for cluster to be ready
  ✔ Create system contract API
[Test] Global setup done
[Test] Starting tests
  Signing
    default constructor
{ ok: null }
      ✔ Should be able derive keypair & sign/verify messages

[Test] Global teardown start
[Test] Internal clean up
[Test] Stopping stack
[Test] Global teardown done

  1 passing (19s)

Done in 22.31s.
```