### PR TITLE
Add new templates to devphase

### DIFF
--- a/workspaces/cli/src/commands/contract/create.ts
+++ b/workspaces/cli/src/commands/contract/create.ts
@@ -20,6 +20,12 @@ export class ContractCreateCommand
             char: 't',
             options: [
                 'flipper',
+                'http_client',
+                'phat_hello',
+                'phat_storage',
+                'signing',
+                'use_cache',
+                'vrf'
             ],
             default: 'flipper',
         })

--- a/workspaces/service/templates/contracts/http_client/Cargo.toml
+++ b/workspaces/service/templates/contracts/http_client/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "{{contract_name}}"
+version = "0.1.0"
+authors = ["[your_name] <[your_email]>"]
+edition = "2021"
+
+[dependencies]
+ink = { version = "4", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+
+pink-extension = { version = "0.5", default-features = false }
+
+[lib]
+name = "{{contract_name}}"
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+    "pink-extension/std",
+]
+ink-as-dependency = []

--- a/workspaces/service/templates/contracts/http_client/lib.rs
+++ b/workspaces/service/templates/contracts/http_client/lib.rs
@@ -1,0 +1,61 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+extern crate alloc;
+
+use pink_extension as pink;
+
+#[pink::contract(env=PinkEnvironment)]
+#[pink(inner=ink::contract)]
+mod {{contract_name}} {
+    use super::pink;
+    use alloc::string::String;
+    use alloc::vec::Vec;
+    use pink::{http_get, http_post, PinkEnvironment};
+
+    #[ink(storage)]
+    pub struct {{ContractName}} {}
+
+    impl {{ContractName}} {
+        #[ink(constructor)]
+        pub fn default() -> Self {
+            Self {}
+        }
+
+        #[ink(message)]
+        pub fn get_ip(&self) -> (u16, Vec<u8>) {
+            let response = http_get!("https://ip.kvin.wang");
+            (response.status_code, response.body)
+        }
+
+        #[ink(message)]
+        pub fn post_data(&self) -> (u16, Vec<u8>) {
+            let response = http_post!("https://example.com", b"payload".to_vec());
+            (response.status_code, response.body)
+        }
+
+        #[ink(message)]
+        pub fn proxy(&self, url: String) -> (u16, Vec<u8>) {
+            let response = http_get!(&url);
+            (response.status_code, response.body)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        #[ink::test]
+        fn get_ip_works() {
+            use pink_extension::chain_extension::{mock, HttpResponse};
+
+            mock::mock_http_request(|request| {
+                if request.url == "https://ip.kvin.wang" {
+                    HttpResponse::ok(b"1.1.1.1".to_vec())
+                } else {
+                HttpResponse::not_found()
+                }
+            });
+
+            let contract = {{contract_name}}::default();
+            assert_eq!(contract.get_ip().1, b"1.1.1.1");
+        }
+    }
+}

--- a/workspaces/service/templates/contracts/phat_hello/Cargo.toml
+++ b/workspaces/service/templates/contracts/phat_hello/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "{{contract_name}}"
+version = "0.1.0"
+authors = ["[your_name] <[your_email]>"]
+edition = "2021"
+
+[dependencies]
+ink = { version = "4", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+
+serde = { version = "1.0.140", default-features = false, features = ["derive"] }
+serde-json-core = { version = "0.4.0" }
+pink-extension = { version = "0.5", default-features = false }
+
+[dev-dependencies]
+pink-extension-runtime = "0.4"
+
+[lib]
+name = "{{contract_name}}"
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+    "pink-extension/std",
+    "serde-json-core/std",
+]
+ink-as-dependency = []

--- a/workspaces/service/templates/contracts/phat_hello/lib.rs
+++ b/workspaces/service/templates/contracts/phat_hello/lib.rs
@@ -1,0 +1,102 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+extern crate alloc;
+
+// pink_extension is short for Phala ink! extension
+use pink_extension as pink;
+
+#[pink::contract(env=PinkEnvironment)]
+mod {{contract_name}} {
+    use super::pink;
+    use pink::{http_get, PinkEnvironment};
+    use scale::{Decode, Encode};
+    use serde::Deserialize;
+    use alloc::string::String;
+    use alloc::format;
+
+    // you have to use crates with `no_std` support in contract.
+    use serde_json_core;
+
+    #[derive(Debug, PartialEq, Eq, Encode, Decode)]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub enum Error {
+        InvalidEthAddress,
+        HttpRequestFailed,
+        InvalidResponseBody,
+    }
+
+    /// Type alias for the contract's result type.
+    pub type Result<T> = core::result::Result<T, Error>;
+
+    /// Defines the storage of your contract.
+    /// All the fields will be encrypted and stored on-chain.
+    /// In this stateless example, we just add a useless field for demo.
+    #[ink(storage)]
+    pub struct {{ContractName}} {
+        demo_field: bool,
+    }
+
+    #[derive(Deserialize, Encode, Clone, Debug, PartialEq)]
+    pub struct EtherscanResponse<'a> {
+        status: &'a str,
+        message: &'a str,
+        result: &'a str,
+    }
+
+    impl {{ContractName}} {
+        /// Constructor to initializes your contract
+        #[ink(constructor)]
+        pub fn new() -> Self {
+            Self { demo_field: true }
+        }
+
+        /// A function to handle direct off-chain Query from users.
+        /// Such functions use the immutable reference `&self`
+        /// so WILL NOT change the contract state.
+        #[ink(message)]
+        pub fn get_eth_balance(&self, account: String) -> Result<String> {
+            if !account.starts_with("0x") && account.len() != 42 {
+                return Err(Error::InvalidEthAddress);
+            }
+
+            // get account ETH balance with HTTP requests to Etherscan
+            // you can send any HTTP requests in Query handler
+            let resp = http_get!(format!(
+                "https://api.etherscan.io/api?module=account&action=balance&address={}",
+                account
+            ));
+            if resp.status_code != 200 {
+                return Err(Error::HttpRequestFailed);
+            }
+
+            let result: EtherscanResponse = serde_json_core::from_slice(&resp.body)
+                .or(Err(Error::InvalidResponseBody))?
+                .0;
+            Ok(String::from(result.result))
+        }
+    }
+
+    /// Unit tests in Rust are normally defined within such a `#[cfg(test)]`
+    /// module and test functions are marked with a `#[test]` attribute.
+    /// The below code is technically just normal Rust code.
+    #[cfg(test)]
+    mod tests {
+        /// Imports all the definitions from the outer scope so we can use them here.
+        use super::*;
+
+        /// We test a simple use case of our contract.
+        #[ink::test]
+        fn it_works() {
+            // when your contract is really deployed, the Phala Worker will do the HTTP requests
+            // mock is needed for local test
+            pink_extension_runtime::mock_ext::mock_all_ext();
+
+            let {{contract_name}} = {{ContractName}}::new();
+            let account = String::from("0xD0fE316B9f01A3b5fd6790F88C2D53739F80B464");
+            let res = {{contract_name}}.get_eth_balance(account.clone());
+            assert!(res.is_ok());
+
+            // run with `cargo +nightly test -- --nocapture` to see the following output
+            println!("Account {} gets {} Wei", account, res.unwrap());
+        }
+    }
+}

--- a/workspaces/service/templates/contracts/phat_storage/Cargo.toml
+++ b/workspaces/service/templates/contracts/phat_storage/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "{{contract_name}}"
+version = "0.1.0"
+authors = ["[your_name] <[your_email]>"]
+edition = "2021"
+
+[dependencies]
+ink = { version = "4", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
+scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+
+pink-extension = { version = "0.5", default-features = false }
+pink-s3 = { version = "0.7", default-features = false }
+
+[lib]
+name = "{{contract_name}}"
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+    "pink-extension/std",
+    "pink-s3/std"
+]
+ink-as-dependency = []

--- a/workspaces/service/templates/contracts/phat_storage/lib.rs
+++ b/workspaces/service/templates/contracts/phat_storage/lib.rs
@@ -1,0 +1,140 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+extern crate alloc;
+use pink_extension as pink;
+
+#[pink::contract(env = PinkEnvironment)]
+mod {{contract_name}} {
+    use pink::PinkEnvironment;
+    use pink_s3 as s3;
+
+    use super::pink;
+
+    use alloc::{vec::Vec, string::String};
+    use scale::{Decode, Encode};
+
+    /// Type alias for the contract's result type.
+    pub type Result<T> = core::result::Result<T, Error>;
+
+    #[derive(Debug, PartialEq, Eq, Encode, Decode)]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub enum Error {
+        NoPermissions,
+        InvalidRequest,
+        KeysNotConfigured,
+    }
+    #[ink(storage)]
+    pub struct {{ContractName}} {
+        admin: AccountId,
+        access_key: String,
+        secret_key: String
+    }
+
+    impl {{ContractName}} {
+        #[ink(constructor)]
+        pub fn new() -> Self {
+            let admin = Self::env().caller();
+            Self {
+                admin,
+                access_key: String::default(),
+                secret_key: String::default()
+            }
+        }
+
+        #[ink(message)]
+        pub fn set_admin(&mut self, new_admin: AccountId) -> Result<()> {
+            if self.admin != self.env().caller() {
+                return Err(Error::NoPermissions);
+            }
+            self.admin = new_admin;
+            Ok(())
+        }
+
+        #[ink(message)]
+        pub fn seal_keys(&mut self, access_key: String, secret_key: String) -> Result<()> {
+            if self.admin != self.env().caller() {
+                return Err(Error::NoPermissions);
+            }
+            self.access_key = access_key;
+            self.secret_key = secret_key;
+            Ok(())
+        }
+
+        #[ink(message)]
+        pub fn s3_put(&self, endpoint: String, region: String, bucket: String, object_key: String, value: Vec<u8>) -> Result<()> {
+            if self.admin != self.env().caller() {
+                return Err(Error::NoPermissions);
+            }
+            if self.access_key == String::default() || self.secret_key == String::default() {
+                return Err(Error::KeysNotConfigured)
+            }
+            let s3_vhm = s3::S3::new(&endpoint.as_str(), &region.as_str(), &self.access_key.as_str(), &self.secret_key.as_str()).unwrap().virtual_host_mode();
+
+            s3_vhm.put(&bucket.as_str(), &object_key.as_str(), &value).or(Err(Error::InvalidRequest));
+
+            Ok(())
+        }
+
+        #[ink(message)]
+        pub fn s3_head(&self, endpoint: String, region: String, bucket: String, object_key: String) -> Result<u64> {
+            if self.access_key == String::default() || self.secret_key == String::default() {
+                return Err(Error::KeysNotConfigured)
+            }
+            let s3_vhm = s3::S3::new(&endpoint.as_str(), &region.as_str(), &self.access_key.as_str(), &self.secret_key.as_str()).unwrap().virtual_host_mode();
+            let head = s3_vhm.head(&bucket.as_str(), &object_key.as_str()).or(Err(Error::InvalidRequest));
+
+            Ok(head.unwrap().content_length)
+        }
+
+        #[ink(message)]
+        pub fn s3_get(&self, endpoint: String, region: String, bucket: String, object_key: String) -> Result<Vec<u8>> {
+            if self.access_key == String::default() || self.secret_key == String::default() {
+                return Err(Error::KeysNotConfigured)
+            }
+            let s3_vhm = s3::S3::new(&endpoint.as_str(), &region.as_str(), &self.access_key.as_str(), &self.secret_key.as_str()).unwrap().virtual_host_mode();
+            let value = s3_vhm.get(&bucket.as_str(), &object_key.as_str()).or(Err(Error::InvalidRequest));
+
+            value
+        }
+
+        #[ink(message)]
+        pub fn s3_delete(&self, endpoint: String, region: String, bucket: String, object_key: String) -> Result<()> {
+            if self.admin != self.env().caller() {
+                return Err(Error::NoPermissions);
+            }
+            if self.access_key == String::default() || self.secret_key == String::default() {
+                return Err(Error::KeysNotConfigured)
+            }
+            let s3_vhm = s3::S3::new(&endpoint.as_str(), &region.as_str(), &self.access_key.as_str(), &self.secret_key.as_str()).unwrap().virtual_host_mode();
+            s3_vhm.delete(&bucket.as_str(), &object_key.as_str()).or(Err(Error::InvalidRequest));
+
+            Ok(())
+        }
+
+        #[ink(message)]
+        pub fn it_works(&self) {
+            // I don't care to expose them.
+            let endpoint = "s3.us-west-1.amazonaws.com";
+            let region = "us-west-1";
+            let access_key = &self.access_key.as_str();
+            let secret_key = &self.secret_key.as_str();
+
+            let s3 = s3::S3::new(endpoint, region, access_key, secret_key)
+                .unwrap()
+                .virtual_host_mode(); // virtual host mode is required for newly created AWS S3 buckets.
+
+            let bucket = "wrlx-aws-s3";
+            let object_key = "path/to/foo";
+            let value = b"bar";
+
+            s3.put(bucket, object_key, value).unwrap();
+
+            let head = s3.head(bucket, object_key).unwrap();
+            assert_eq!(head.content_length, value.len() as u64);
+
+            let v = s3.get(bucket, object_key).unwrap();
+            assert_eq!(v, value);
+
+            s3.delete(bucket, object_key).unwrap();
+        }
+    }
+}

--- a/workspaces/service/templates/contracts/signing/Cargo.toml
+++ b/workspaces/service/templates/contracts/signing/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "{{contract_name}}"
+version = "0.1.0"
+authors = ["[your_name] <[your_email]>"]
+edition = "2021"
+
+[dependencies]
+ink = { version = "4", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.1", default-features = false, features = ["derive"], optional = true }
+
+pink-extension = { version = "0.5", default-features = false }
+
+[dev-dependencies]
+pink-extension-runtime = "0.5"
+
+[lib]
+name = "{{contract_name}}"
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+    "pink-extension/std",
+]
+ink-as-dependency = []

--- a/workspaces/service/templates/contracts/signing/lib.rs
+++ b/workspaces/service/templates/contracts/signing/lib.rs
@@ -1,0 +1,76 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+extern crate alloc;
+
+use pink_extension as pink;
+
+#[pink::contract(env=PinkEnvironment)]
+mod {{contract_name}} {
+    use super::pink;
+    use pink::chain_extension::signing as sig;
+    use sig::SigType;
+    use pink::PinkEnvironment;
+    use alloc::{string::String, vec::Vec};
+
+    #[ink(storage)]
+    pub struct {{ContractName}} {
+        privkey: Vec<u8>,
+        pubkey: Vec<u8>,
+    }
+
+    impl {{ContractName}} {
+        /// Constructor to initializes your contract
+        #[ink(constructor)]
+        pub fn default() -> Self {
+            let gen_privkey = sig::derive_sr25519_key(b"a spoon of salt");
+            let gen_pubkey = sig::get_public_key(&gen_privkey, SigType::Sr25519);
+            Self {
+                privkey: gen_privkey,
+                pubkey: gen_pubkey,
+            }
+        }
+
+        #[ink(message)]
+        pub fn sign(&self, message: String) -> Vec<u8> {
+            let signature = sig::sign(message.as_bytes(), &self.privkey, SigType::Sr25519);
+            signature
+        }
+
+        #[ink(message)]
+        pub fn verify(&self, message: String, signature: Vec<u8>) -> bool {
+            let pass = sig::verify(message.as_bytes(), &self.pubkey, &signature, SigType::Sr25519);
+            pass
+        }
+
+        #[ink(message)]
+        pub fn test(&self) {
+            let privkey = sig::derive_sr25519_key(b"a spoon of salt");
+            let pubkey = sig::get_public_key(&privkey, SigType::Sr25519);
+            let message = b"hello world";
+            let signature = sig::sign(message, &privkey, SigType::Sr25519);
+            let pass = sig::verify(message, &pubkey, &signature, SigType::Sr25519);
+            assert!(pass);
+            let pass = sig::verify(b"Fake", &pubkey, &signature, SigType::Sr25519);
+            assert!(!pass);
+        }
+    }
+
+    /// Unit tests in Rust are normally defined within such a `#[cfg(test)]`
+    /// module and test functions are marked with a `#[test]` attribute.
+    /// The below code is technically just normal Rust code.
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[ink::test]
+        fn it_works() {
+            pink_extension_runtime::mock_ext::mock_all_ext();
+
+            let contract = {{ContractName}}::default();
+            let message = String::from("hello world");
+            let sign_message = contract.sign(message.clone());
+            let verify_signature = contract.verify(message.clone(), sign_message);
+            assert!(verify_signature);
+            contract.test(message);
+        }
+    }
+}

--- a/workspaces/service/templates/contracts/use_cache/Cargo.toml
+++ b/workspaces/service/templates/contracts/use_cache/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "{{contract_name}}"
+version = "0.1.0"
+authors = ["[your_name] <[your_email]>"]
+edition = "2021"
+
+[dependencies]
+ink = { version = "4", default-features = false }
+
+scale = { package = "parity-scale-codec", version = "3.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.1", default-features = false, features = ["derive"], optional = true }
+
+pink-extension = { version = "0.5", default-features = false }
+
+[lib]
+name = "{{contract_name}}"
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+    "pink-extension/std",
+]
+ink-as-dependency = []

--- a/workspaces/service/templates/contracts/use_cache/lib.rs
+++ b/workspaces/service/templates/contracts/use_cache/lib.rs
@@ -1,0 +1,88 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+extern crate alloc;
+use pink_extension as pink;
+
+#[pink::contract(env=PinkEnvironment)]
+mod {{contract_name}} {
+    use super::pink;
+    use pink::chain_extension::pink_extension_instance as ext;
+    use pink::PinkEnvironment;
+    use alloc::vec::Vec;
+    use scale::{Decode, Encode};
+
+    /// Type alias for the contract's result type.
+    pub type Result<T> = core::result::Result<T, Error>;
+
+    #[derive(Debug, PartialEq, Eq, Encode, Decode)]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub enum Error {
+        KeyValueNotSet,
+        InvalidKeyValue,
+    }
+
+    #[ink(storage)]
+    pub struct {{ContractName}} {}
+
+    impl {{ContractName}} {
+        #[ink(constructor)]
+        pub fn default() -> Self {
+            Self {}
+        }
+
+        #[ink(message)]
+        pub fn get_key_value(&self) -> Option<Vec<u8>> {
+            ext().cache_get(b"key")
+        }
+
+        #[ink(message)]
+        pub fn set_key_value(&self, value: Vec<u8>) -> Result<()> {
+            ext().cache_set(b"key", &value).or(Err(Error::KeyValueNotSet))
+        }
+
+        #[ink(message)]
+        pub fn test(&self) {
+            assert!(ext().cache_set(b"key", b"value").is_ok());
+            assert_eq!(ext().cache_get(b"key"), Some(b"value".to_vec()));
+            assert_eq!(ext().cache_remove(b"key"), Some(b"value".to_vec()));
+            assert_eq!(ext().cache_get(b"key"), None);
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[ink::test]
+        fn it_works() {
+            use pink_extension::chain_extension::mock;
+            use std::{cell::RefCell, collections::HashMap, rc::Rc};
+
+            let storage: Rc<RefCell<HashMap<Vec<u8>, Vec<u8>>>> = Default::default();
+
+            {
+                let storage = storage.clone();
+                mock::mock_cache_set(move |k, v| {
+                    storage.borrow_mut().insert(k.to_vec(), v.to_vec());
+                    Ok(())
+                });
+            }
+            {
+                let storage = storage.clone();
+                mock::mock_cache_get(move |k| storage.borrow().get(k).map(|v| v.to_vec()));
+            }
+            {
+                let storage = storage.clone();
+                mock::mock_cache_remove(move |k| {
+                    storage.borrow_mut().remove(k).map(|v| v.to_vec())
+                });
+            }
+
+            let contract = {{ContractName}}::default();
+            contract.test();
+            contract.set_key_value(b"hashwarlock was here".to_vec());
+            assert_eq!(contract.get_key_value(), Some(b"hashwarlock was here".to_vec()));
+            contract.test();
+            assert_ne!(contract.get_key_value(), Some(b"hashwarlock was here".to_vec()));
+        }
+    }
+}

--- a/workspaces/service/templates/contracts/vrf/Cargo.toml
+++ b/workspaces/service/templates/contracts/vrf/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "{{contract_name}}"
+version = "0.0.1"
+authors = ["[your_name] <[your_email]>"]
+edition = "2021"
+
+[dependencies]
+ink = { version = "4", default-features = false }
+ink_storage = { version = "4", default-features = false }
+pink-extension = { version = "0.5", default-features = false }
+this-crate = "0.1.0"
+
+scale = { package = "parity-scale-codec", version = "3.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.1", default-features = false, features = ["derive"], optional = true }
+
+[dev-dependencies]
+pink-extension-runtime = "0.5"
+
+[lib]
+name = "{{contract_name}}"
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+    "pink-extension/std",
+]
+ink-as-dependency = []

--- a/workspaces/service/templates/contracts/vrf/lib.rs
+++ b/workspaces/service/templates/contracts/vrf/lib.rs
@@ -1,0 +1,36 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+extern crate alloc;
+
+use pink_extension as pink;
+
+#[pink::contract(env=PinkEnvironment)]
+#[pink(inner=ink::contract)]
+mod {{contract_name}} {
+    use super::pink;
+    use pink::PinkEnvironment;
+    use this_crate::{version_tuple, VersionTuple};
+    use alloc::vec::Vec;
+
+    #[ink(storage)]
+    pub struct {{ContractName}} {
+    }
+
+
+    impl {{ContractName}} {
+        #[ink(constructor)]
+        pub fn default() -> Self {
+            Self {}
+        }
+
+        #[ink(message)]
+        pub fn version(&self) -> VersionTuple {
+            version_tuple!()
+        }
+
+        #[ink(message)]
+        pub fn get_randomness(&self, salt: Vec<u8>) -> (Vec<u8>, Vec<u8>) {
+            let result = pink::vrf(&salt);
+            (salt, result)
+        }
+    }
+}

--- a/workspaces/service/templates/tests/http_client/http_client.test.ts
+++ b/workspaces/service/templates/tests/http_client/http_client.test.ts
@@ -1,0 +1,38 @@
+import { ContractType } from '@devphase/service';
+import * as PhalaSdk from '@phala/sdk';
+import type { KeyringPair } from '@polkadot/keyring/types';
+import { stringToHex } from '@polkadot/util';
+import { HttpClient } from "@/typings/HttpClient";
+
+describe("HttpClient test", () => {
+    let factory: HttpClient.Factory;
+    let contract: HttpClient.Contract;
+    let signer: KeyringPair;
+    let certificate : PhalaSdk.CertificateData;
+
+    before(async function setup(): Promise<void> {
+        factory = await this.devPhase.getFactory(
+            './contracts/http_client/target/ink/http_client.contract',
+            { contractType: ContractType.InkCode }
+        );
+
+        await factory.deploy();
+
+        signer = this.devPhase.accounts.bob;
+        certificate = await PhalaSdk.signCertificate({
+            api: this.api,
+            pair: signer,
+        });
+    });
+
+    describe('default constructor', () => {
+        before(async function() {
+            contract = await factory.instantiate('default', []);
+        });
+
+        it('Should be able...', async function() {
+            const response = await contract.query.proxy(certificate, {}, 'https://wttr.in/berlin?ATm');
+            console.log(response.output.toJSON());
+        });
+    });
+});

--- a/workspaces/service/templates/tests/phat_hello/phat_hello.test.ts
+++ b/workspaces/service/templates/tests/phat_hello/phat_hello.test.ts
@@ -1,0 +1,45 @@
+import { PhatHello } from '@/typings/PhatHello';
+import { ContractType } from '@devphase/service';
+import * as PhalaSdk from '@phala/sdk';
+import type { KeyringPair } from '@polkadot/keyring/types';
+import { stringToHex } from '@polkadot/util';
+
+
+describe('PhatHello', () => {
+    let factory : PhatHello.Factory;
+    let contract : PhatHello.Contract;
+    let signer : KeyringPair;
+    let cert : PhalaSdk.CertificateData;
+
+    before(async function() {
+        factory = await this.devPhase.getFactory(
+            'phat_hello',
+            { contractType: ContractType.InkCode }
+        );
+
+        await factory.deploy();
+
+        signer = this.devPhase.accounts.bob;
+        cert = await PhalaSdk.signCertificate({ pair: signer });
+    });
+
+    describe('new constructor', () => {
+        before(async function() {
+            contract = await factory.instantiate('new', []);
+        });
+        const address = '0xD0fE316B9f01A3b5fd6790F88C2D53739F80B464';
+        const hex_address = stringToHex(address);
+
+        it('Should be able to query balance of an account on Ethereum', async function() {
+            const response = await contract.query.getEthBalance(signer.address, { cert }, hex_address);
+            const human = response.output.toHuman();
+            const primitive = response.output.toPrimitive();
+            const json = response.output.toJSON();
+
+            console.log(human.Ok.Ok);
+            console.log(primitive.ok.ok);
+            console.log(json.ok.ok);
+        });
+    });
+
+});

--- a/workspaces/service/templates/tests/phat_storage/phat_storage.test.ts
+++ b/workspaces/service/templates/tests/phat_storage/phat_storage.test.ts
@@ -1,0 +1,60 @@
+import { ContractType, TxHandler } from '@devphase/service';
+import * as PhalaSdk from '@phala/sdk';
+import type { KeyringPair } from '@polkadot/keyring/types';
+import { stringToHex } from '@polkadot/util';
+import { PhatStorage } from "@/typings/PhatStorage";
+
+describe("PhatStorage test", () => {
+    let factory: PhatStorage.Factory;
+    let contract: PhatStorage.Contract;
+    let signer: KeyringPair;
+    let certificate : PhalaSdk.CertificateData;
+
+    before(async function setup(): Promise<void> {
+        factory = await this.devPhase.getFactory(
+            './contracts/phat_storage/target/ink/phat_storage.contract',
+            { contractType: ContractType.InkCode }
+        );
+
+        await factory.deploy();
+
+        signer = this.devPhase.accounts.bob;
+        certificate = await PhalaSdk.signCertificate({
+            api: this.api,
+            pair: signer,
+        });
+    });
+
+    describe('new constructor', () => {
+        before(async function() {
+            contract = await factory.instantiate('new', []);
+        });
+
+        it('Should be able to seal keys', async function() {
+            await TxHandler.handle(contract.tx.sealKeys(
+                    { gasLimit: "10000000000000" },
+                    "ACCESS_KEY",
+                    "SECRET_KEY"
+                ),
+                signer,
+                true
+            );
+            const response = await contract.query.itWorks(certificate, {});
+            console.log(response);
+            const getResp = await contract.query.s3Get(certificate, {}, "s3.us-west-1.amazonaws.com", "us-west-1", "wrlx-aws-s3", "path/to/foo");
+            console.log(getResp);
+        });
+        it('Should be able to perform put to s3 bucket and get object key value', async function() {
+            const putResp = await contract.query.s3Put(certificate, {}, "s3.us-west-1.amazonaws.com", "us-west-1", "wrlx-aws-s3", "path/to/foo", 'bar');
+            console.log(putResp.output.toJSON());
+            const getResp = await contract.query.s3Get(certificate, {}, "s3.us-west-1.amazonaws.com", "us-west-1", "wrlx-aws-s3", "path/to/foo");
+            console.log(`Object Key: ["path/to/foo"] -> Value: ${getResp.output.toJSON().ok.ok.toString()}`);
+        });
+        it('Should be able to delete object key value from bucket', async function() {
+            const putResp = await contract.query.s3Delete(certificate, {}, "s3.us-west-1.amazonaws.com", "us-west-1", "wrlx-aws-s3", "path/to/foo");
+            console.log(putResp.output.toJSON());
+            const getResp = await contract.query.s3Get(certificate, {}, "s3.us-west-1.amazonaws.com", "us-west-1", "wrlx-aws-s3", "path/to/foo");
+            console.log(`Object Key: ["path/to/foo"] -> Value: ${getResp}`);
+        });
+    });
+});

--- a/workspaces/service/templates/tests/signing/signing.test.ts
+++ b/workspaces/service/templates/tests/signing/signing.test.ts
@@ -1,0 +1,47 @@
+import { ContractType } from '@devphase/service';
+import * as PhalaSdk from '@phala/sdk';
+import type { KeyringPair } from '@polkadot/keyring/types';
+import { stringToHex } from '@polkadot/util';
+import { Signing } from "@/typings/Signing";
+
+describe("Signing test", () => {
+    let factory: Signing.Factory;
+    let contract: Signing.Contract;
+    let signer: KeyringPair;
+    let certificate : PhalaSdk.CertificateData;
+
+    before(async function() {
+        factory = await this.devPhase.getFactory(
+            './contracts/signing/target/ink/signing.contract',
+            { contractType: ContractType.InkCode }
+        );
+
+        await factory.deploy();
+
+        signer = this.devPhase.accounts.bob;
+        certificate = await PhalaSdk.signCertificate({
+            api: this.api,
+            pair: signer,
+        });
+    });
+
+    describe('new constructor', () => {
+        before(async function() {
+            contract = await factory.instantiate('default', []);
+        });
+        const message = 'hi, how are ya?';
+
+        it('Should be able derive keypair & sign/verify messages', async function() {
+            const response = await contract.query.test(certificate, {});
+            console.log(response.output.toJSON());
+        });
+
+        it('Should be able derive keypair & sign/verify messages', async function() {
+            const signResponse = await contract.query.sign(certificate, {}, message);
+            const signMessage = signResponse.output.toJSON().ok;
+            console.log(signResponse.output.toJSON());
+            const verifyResponse = await contract.query.verify(certificate, {}, signMessage);
+            expect(verifyResponse.output.toJSON()).to.be.eql({ok: true});
+        });
+    });
+});

--- a/workspaces/service/templates/tests/use_cache/use_cache.test.ts
+++ b/workspaces/service/templates/tests/use_cache/use_cache.test.ts
@@ -1,0 +1,41 @@
+import { ContractType } from '@devphase/service';
+import * as PhalaSdk from '@phala/sdk';
+import type { KeyringPair } from '@polkadot/keyring/types';
+import { stringToHex } from '@polkadot/util';
+import { UseCache } from "@/typings/UseCache";
+
+describe("UseCache test", () => {
+    let factory: UseCache.Factory;
+    let contract: UseCache.Contract;
+    let signer: KeyringPair;
+    let certificate : PhalaSdk.CertificateData;
+
+    before(async function setup(): Promise<void> {
+        factory = await this.devPhase.getFactory(
+            './contracts/use_cache/target/ink/use_cache.contract',
+            { contractType: ContractType.InkCode }
+        );
+
+        await factory.deploy();
+
+        signer = this.devPhase.accounts.bob;
+        certificate = await PhalaSdk.signCertificate({
+            api: this.api,
+            pair: signer,
+        });
+    });
+
+    describe('default constructor', () => {
+        before(async function() {
+            contract = await factory.instantiate('default', []);
+        });
+        const message = 'hi, how are ya?';
+
+        it('Should be able to add and get cache', async function() {
+            const response = await contract.query.setKeyValue(certificate, {}, message);
+            console.log(response.output.toJSON());
+            const getResponse = await contract.query.getKeyValue(certificate, {});
+            console.log(getResponse.output.toJSON());
+        });
+    });
+});

--- a/workspaces/service/templates/tests/vrf/vrf.test.ts
+++ b/workspaces/service/templates/tests/vrf/vrf.test.ts
@@ -1,0 +1,39 @@
+import { ContractType } from '@devphase/service';
+import * as PhalaSdk from '@phala/sdk';
+import type { KeyringPair } from '@polkadot/keyring/types';
+import { stringToHex } from '@polkadot/util';
+import { Vrf } from "@/typings/Vrf";
+
+describe("Vrf test", () => {
+    let factory: Vrf.Factory;
+    let contract: Vrf.Contract;
+    let signer: KeyringPair;
+    let certificate : PhalaSdk.CertificateData;
+
+    before(async function setup(): Promise<void> {
+        factory = await this.devPhase.getFactory(
+            './contracts/vrf/target/ink/vrf.contract',
+            { contractType: ContractType.InkCode }
+        );
+
+        await factory.deploy();
+
+        signer = this.devPhase.accounts.bob;
+        certificate = await PhalaSdk.signCertificate({
+            api: this.api,
+            pair: signer,
+        });
+    });
+
+    describe('default constructor', () => {
+        before(async function() {
+            contract = await factory.instantiate('default', []);
+        });
+        const salt = 'hi, how are ya?';
+
+        it('Should be able to add and get cache', async function() {
+            const response = await contract.query.getRandomness(certificate, {}, salt);
+            console.log(response.output.toJSON());
+        });
+    });
+});


### PR DESCRIPTION
## Description
Add support for more templates to be created in devphase.
- http_client
- phat_hello
- phat_storage
- signing
- use_cache
- vrf

Currently all tests end up getting downloaded during the `devphase init` command. I did not want to mess with the functionality and cause anything to break, but this may need to be changed to only copy the flipper test. Then other tests can be added during the `devphase contract create` command.

Tests work locally when pointing to the locally built `@devphase/service` with the added templates.